### PR TITLE
add LDP container support for annotation endpoints (WIP)

### DIFF
--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -1,0 +1,107 @@
+const Boom = require('@hapi/boom')
+const etag = require('etag')
+
+class PagedCollection {
+  constructor(getPage, total, pageSize) {
+    if (Array.isArray(getPage)) {
+      const items = getPage
+      this._getPage = () => items
+      this.total = items.length
+      this.pageSize = Infinity
+    } else {
+      this._getPage = getPage
+      this.total = total
+      this.pageSize = pageSize
+    }
+  }
+
+  getPage(pageNumber) {
+    return this._getPage(pageNumber, this.pageSize)
+  }
+
+  get lastPage() {
+    return this.pageSize === Infinity
+      ? 0
+      : Math.floor(this.total / this.pageSize)
+  }
+}
+
+function createPage(h, collection, pageNumber, iris) {
+  if (pageNumber > collection.lastPage) {
+    return Boom.notFound()
+  }
+
+  const page = {
+    '@context': 'http://www.w3.org/ns/anno.jsonld',
+    id: `http://example.org/annotations/?iris=${
+      iris ? 1 : 0
+    }&page=${pageNumber}`,
+    type: 'AnnotationPage',
+    partOf: {
+      id: `http://example.org/annotations/?iris=${iris ? 1 : 0}`,
+      total: collection.total,
+      modified: '2016-07-20T12:00:00Z',
+    },
+    startIndex: pageNumber === 0 ? 0 : collection.pageSize * pageNumber,
+    items: collection.getPage(pageNumber),
+  }
+
+  const response = h.response(page)
+  response.type(
+    'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
+  )
+  response.header('allow', 'HEAD, GET, OPTIONS')
+
+  return response
+}
+
+function createContainer(h, collection, iris) {
+  const container = {
+    '@context': [
+      'http://www.w3.org/ns/anno.jsonld',
+      'http://www.w3.org/ns/ldp.jsonld',
+    ],
+    id: 'http://example.org/annotations/?iris=1',
+    type: ['BasicContainer', 'AnnotationCollection'],
+    total: collection.total,
+    modified: '2016-07-20T12:00:00Z',
+    label: 'tbd',
+    first: `http://example.org/annotations/?iris=${iris ? 1 : 0}&page=0`,
+    ...(collection.lastPage > 0 && {
+      last: `http://example.org/annotations/?iris=${iris ? 1 : 0}&page=${
+        collection.lastPage
+      }`,
+    }),
+  }
+
+  const response = h.response(container)
+  response.header('link', [
+    '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"',
+    '<http://www.w3.org/TR/annotation-protocol/>; rel="http://www.w3.org/ns/ldp#constrainedBy"',
+  ])
+  response.header(
+    'Accept-Post',
+    'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
+  )
+  response.type(
+    'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
+  )
+  response.header('allow', 'HEAD, GET, POST, OPTIONS')
+  response.etag(etag(JSON.stringify(container)))
+
+  return response
+}
+
+function wrapResource(h, annotation) {
+  const response = h.response(annotation)
+  response.etag(etag(JSON.stringify(annotation)))
+  response.type(
+    'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
+  )
+  response.header('allow', 'OPTIONS,HEAD,GET,PUT,DELETE')
+  response.header('link', '<http://www.w3.org/ns/ldp#Resource>; rel="type"')
+
+  return response
+}
+
+module.exports = {PagedCollection, createPage, createContainer, wrapResource}

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -2,7 +2,7 @@ const Boom = require('@hapi/boom')
 const etag = require('etag')
 
 class PagedCollection {
-  constructor(getPage, total, pageSize) {
+  constructor(getPage, notebookInfo, total, pageSize) {
     if (Array.isArray(getPage)) {
       const items = getPage
       this._getPage = () => items
@@ -13,6 +13,7 @@ class PagedCollection {
       this.total = total
       this.pageSize = pageSize
     }
+    this.notebookInfo = notebookInfo
   }
 
   getPage(pageNumber) {
@@ -31,19 +32,19 @@ function createPage(h, collection, pageNumber, iris) {
     return Boom.notFound()
   }
 
+  const items = collection.getPage(pageNumber)
+  const containerUrl = collection.notebookInfo.getContainerUrl()
   const page = {
     '@context': 'http://www.w3.org/ns/anno.jsonld',
-    id: `http://example.org/annotations/?iris=${
-      iris ? 1 : 0
-    }&page=${pageNumber}`,
+    id: `${containerUrl}/?page=${pageNumber}&iris=${iris ? 1 : 0}`,
     type: 'AnnotationPage',
     partOf: {
-      id: `http://example.org/annotations/?iris=${iris ? 1 : 0}`,
+      id: `${containerUrl}/?iris=${iris ? 1 : 0}`,
       total: collection.total,
       modified: '2016-07-20T12:00:00Z',
     },
     startIndex: pageNumber === 0 ? 0 : collection.pageSize * pageNumber,
-    items: collection.getPage(pageNumber),
+    items: iris ? items.map(item => item.id) : items,
   }
 
   const response = h.response(page)
@@ -56,21 +57,20 @@ function createPage(h, collection, pageNumber, iris) {
 }
 
 function createContainer(h, collection, iris) {
+  const containerUrl = collection.notebookInfo.getContainerUrl()
   const container = {
     '@context': [
       'http://www.w3.org/ns/anno.jsonld',
       'http://www.w3.org/ns/ldp.jsonld',
     ],
-    id: 'http://example.org/annotations/?iris=1',
+    id: `${containerUrl}/?iris=${iris ? 1 : 0}`,
     type: ['BasicContainer', 'AnnotationCollection'],
     total: collection.total,
     modified: '2016-07-20T12:00:00Z',
     label: 'tbd',
-    first: `http://example.org/annotations/?iris=${iris ? 1 : 0}&page=0`,
+    first: `${containerUrl}/?iris=${iris ? 1 : 0}&page=0`,
     ...(collection.lastPage > 0 && {
-      last: `http://example.org/annotations/?iris=${iris ? 1 : 0}&page=${
-        collection.lastPage
-      }`,
+      last: `${containerUrl}/?iris=${iris ? 1 : 0}&page=${collection.lastPage}`,
     }),
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,7 +2,12 @@ const assert = require('assert')
 const Hapi = require('@hapi/hapi')
 const Boom = require('@hapi/boom')
 const WebSocketPlugin = require('hapi-plugin-websocket')
-const etag = require('etag')
+const {
+  PagedCollection,
+  createContainer,
+  createPage,
+  wrapResource,
+} = require('./ldp')
 const {
   SwarmError,
   ERROR_NOT_FOUND,
@@ -62,74 +67,24 @@ async function createServer(backendSwarm, port, {host, ssl}) {
     method: 'GET',
     path: '/annotations/{container}',
     handler: async (request, h) => {
-      const page = request.query.page
+      const pageNumber = request.query.page
         ? Number.parseInt(request.query.page)
         : null
       const iris = request.query.iris === '1'
-      if (page !== null && page !== 0) {
-        return Boom.notFound()
-      }
 
       const docUrl = decodeDocUrl(request.params.container)
       try {
         const annotations = await backendSwarm.getAnnotations(docUrl)
-        const denormalizedAnnotations = annotations.map(annotation =>
-          denormalizeAnnotation(host, docUrl, annotation, {ssl})
-        )
-
-        if (page !== null) {
-          const container = {
-            '@context': 'http://www.w3.org/ns/anno.jsonld',
-            id: 'http://example.org/annotations/?iris=0&page=0',
-            type: 'AnnotationPage',
-            partOf: {
-              id: 'http://example.org/annotations/?iris=0',
-              total: denormalizedAnnotations.length,
-              modified: '2016-07-20T12:00:00Z',
-            },
-            startIndex: 0,
-            items: denormalizedAnnotations,
-          }
-
-          const response = h.response(container)
-          response.type(
-            'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
+        const collection = new PagedCollection(
+          annotations.map(annotation =>
+            denormalizeAnnotation(host, docUrl, annotation, {ssl})
           )
-          response.header('allow', 'HEAD, GET, OPTIONS')
-
-          return response
-        }
-
-        const container = {
-          '@context': [
-            'http://www.w3.org/ns/anno.jsonld',
-            'http://www.w3.org/ns/ldp.jsonld',
-          ],
-          id: 'http://example.org/annotations/?iris=1',
-          type: ['BasicContainer', 'AnnotationCollection'],
-          total: denormalizedAnnotations.length,
-          modified: '2016-07-20T12:00:00Z',
-          label: 'tbc',
-          first: 'http://example.org/annotations/?iris=1&page=0',
-          last: 'http://example.org/annotations/?iris=1&page=42',
-        }
-
-        const response = h.response(container)
-        response.header('link', [
-          '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"',
-          '<http://www.w3.org/TR/annotation-protocol/>; rel="http://www.w3.org/ns/ldp#constrainedBy"',
-        ])
-        response.header(
-          'Accept-Post',
-          'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
         )
-        response.type(
-          'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
-        )
-        response.header('allow', 'HEAD, GET, POST, OPTIONS')
-        response.etag(etag(JSON.stringify(container)))
 
-        return response
+        if (pageNumber !== null) {
+          return createPage(h, collection, pageNumber, iris)
+        }
+        return createContainer(h, collection, iris)
       } catch (err) {
         return handleError(err)
       }
@@ -191,24 +146,8 @@ async function createServer(backendSwarm, port, {host, ssl}) {
           docUrl,
           request.params.id
         )
-        const denormalizedAnnotations = denormalizeAnnotation(
-          host,
-          docUrl,
-          annotation,
-          {ssl}
-        )
-        const response = h.response(denormalizedAnnotations)
-        response.etag(etag(JSON.stringify(denormalizedAnnotations)))
-        response.type(
-          'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
-        )
-        response.header('allow', 'OPTIONS,HEAD,GET,PUT,DELETE')
-        response.header(
-          'link',
-          '<http://www.w3.org/ns/ldp#Resource>; rel="type"'
-        )
-
-        return response
+        const resource = denormalizeAnnotation(host, docUrl, annotation, {ssl})
+        return wrapResource(h, resource)
       } catch (err) {
         return handleError(err)
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -62,12 +62,74 @@ async function createServer(backendSwarm, port, {host, ssl}) {
     method: 'GET',
     path: '/annotations/{container}',
     handler: async (request, h) => {
+      const page = request.query.page
+        ? Number.parseInt(request.query.page)
+        : null
+      const iris = request.query.iris === '1'
+      if (page !== null && page !== 0) {
+        return Boom.notFound()
+      }
+
       const docUrl = decodeDocUrl(request.params.container)
       try {
         const annotations = await backendSwarm.getAnnotations(docUrl)
-        return annotations.map(annotation =>
+        const denormalizedAnnotations = annotations.map(annotation =>
           denormalizeAnnotation(host, docUrl, annotation, {ssl})
         )
+
+        if (page !== null) {
+          const container = {
+            '@context': 'http://www.w3.org/ns/anno.jsonld',
+            id: 'http://example.org/annotations/?iris=0&page=0',
+            type: 'AnnotationPage',
+            partOf: {
+              id: 'http://example.org/annotations/?iris=0',
+              total: denormalizedAnnotations.length,
+              modified: '2016-07-20T12:00:00Z',
+            },
+            startIndex: 0,
+            items: denormalizedAnnotations,
+          }
+
+          const response = h.response(container)
+          response.type(
+            'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
+          )
+          response.header('allow', 'HEAD, GET, OPTIONS')
+
+          return response
+        }
+
+        const container = {
+          '@context': [
+            'http://www.w3.org/ns/anno.jsonld',
+            'http://www.w3.org/ns/ldp.jsonld',
+          ],
+          id: 'http://example.org/annotations/?iris=1',
+          type: ['BasicContainer', 'AnnotationCollection'],
+          total: denormalizedAnnotations.length,
+          modified: '2016-07-20T12:00:00Z',
+          label: 'tbc',
+          first: 'http://example.org/annotations/?iris=1&page=0',
+          last: 'http://example.org/annotations/?iris=1&page=42',
+        }
+
+        const response = h.response(container)
+        response.header('link', [
+          '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"',
+          '<http://www.w3.org/TR/annotation-protocol/>; rel="http://www.w3.org/ns/ldp#constrainedBy"',
+        ])
+        response.header(
+          'Accept-Post',
+          'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
+        )
+        response.type(
+          'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
+        )
+        response.header('allow', 'HEAD, GET, POST, OPTIONS')
+        response.etag(etag(JSON.stringify(container)))
+
+        return response
       } catch (err) {
         return handleError(err)
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,7 @@ const {
   ERROR_BAD_REQUEST,
 } = require('./error')
 const {
+  NotebookInfo,
   encodeDocUrl,
   decodeDocUrl,
   normalizeAnnotation,
@@ -67,18 +68,20 @@ async function createServer(backendSwarm, port, {host, ssl}) {
     method: 'GET',
     path: '/annotations/{container}',
     handler: async (request, h) => {
+      const docUrl = decodeDocUrl(request.params.container)
       const pageNumber = request.query.page
         ? Number.parseInt(request.query.page)
         : null
       const iris = request.query.iris === '1'
+      const notebookInfo = new NotebookInfo(host, ssl, docUrl)
 
-      const docUrl = decodeDocUrl(request.params.container)
       try {
         const annotations = await backendSwarm.getAnnotations(docUrl)
         const collection = new PagedCollection(
           annotations.map(annotation =>
             denormalizeAnnotation(host, docUrl, annotation, {ssl})
-          )
+          ),
+          notebookInfo
         )
 
         if (pageNumber !== null) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,6 +2,20 @@ const encodeDocUrl = docUrl => Buffer.from(docUrl).toString('hex')
 const decodeDocUrl = encodedDocUrl =>
   Buffer.from(encodedDocUrl, 'hex').toString()
 
+class NotebookInfo {
+  constructor(host, ssl, docUrl) {
+    this.host = host
+    this.ssl = ssl
+    this.docUrl = docUrl
+  }
+
+  getContainerUrl() {
+    return `${this.ssl ? 'https' : 'http'}://${
+      this.host
+    }/annotations/${encodeDocUrl(this.docUrl)}`
+  }
+}
+
 function normalizeId(host, docUrl, annotationId, opts = {}) {
   const ssl = opts.ssl || false
   const pattern = new RegExp(
@@ -33,6 +47,7 @@ const denormalizeAnnotation = (host, docUrl, annotation, opts = {}) => {
 }
 
 module.exports = {
+  NotebookInfo,
   normalizeId,
   normalizeAnnotation,
   denormalizeAnnotation,

--- a/tools/touch.js
+++ b/tools/touch.js
@@ -14,5 +14,3 @@ const handle = repo.watch(url, () => {})
 console.log(`New notebook created.
 Document URL: ${url}
 Encoded URL: ${encodeDocUrl(url)}`)
-
-process.on('SIGINT', () => handle.close())


### PR DESCRIPTION
support LDP container endpoints and pagination with appropriate HTTP headers: https://www.w3.org/TR/annotation-protocol/#annotation-containers

* [x] draft LDP support
* [x] set URLs with respective hostname/SSL/port
* [x] support IRIs parameter
* [ ] include all headers for containers/pages
* [ ] include all headers for POST/PUT/DELETE
* [ ] respect container presentation preferences (https://www.w3.org/TR/annotation-protocol/#container-representation-preferences)
